### PR TITLE
Clarify RIT location and co-op requirements

### DIFF
--- a/app/markdown/governing-docs/constitution.md
+++ b/app/markdown/governing-docs/constitution.md
@@ -19,19 +19,19 @@ lifestyle or background.
 
 Code of Conduct
 ---------------
-As active members of the RIT community, advocates of software engineering, and
-future workers in the computing industry, the Society's members are expected to
-demonstrate the highest levels of personal and professional conduct.  
+As active members of the Rochester Institute of Technology community, advocates
+of software engineering, and future workers in the computing industry, the Society's
+members are expected to demonstrate the highest levels of personal and professional conduct.  
 
 At the core of all efforts as Society members, we will:
 * Demonstrate civility, respect, decency and sensitivity towards our fellow
-  members of the RIT community.
+  members of the Rochester Institute of Technology community.
 * Conduct ourselves with the highest standards of moral and ethical behavior.
   Such behavior includes taking responsibility for our own personal choices,
   decisions and academic and professional work.
-* Affirm through the daily demonstration of these ideals that RIT is a
-  university devoted to the pursuit of knowledge and a free exchange of ideas
-  in an open and respectful environment.
+* Affirm through the daily demonstration of these ideals that the Rochester Institute
+  of Technology is a university devoted to the pursuit of knowledge and a free
+  exchange of ideas in an open and respectful environment.
 
 Conduct prohibited by these policies is unacceptable in both the SSE facilities, as
 well as any related setting, such as off-campus social events.
@@ -53,8 +53,9 @@ The Pillars shall be valued equally, and are listed here in no particular
 order.
 
 ### Mentoring
-The Society shall promote the academic success of members of the RIT community,
-with a focus on material related to Software Engineering.
+The Society shall promote the academic success of members of the Rochester
+Institute of Technology community, with a focus on material related to
+Software Engineering.
 
 ### Networking
 The Society shall maintain relationships with prospective employers, sponsors,
@@ -89,8 +90,9 @@ any benefits.
 A candidate must satisfy all of the following requirements to be an active
 member: 
 
-1. The candidate must be enrolled as a student at RIT or NTID. 
-2. The candidate must make at least one significant contribution to the
+1. The candidate must be enrolled as a student at the Rochester Institute of
+   Technology in Henrietta, New York, United States.
+3. The candidate must make at least one significant contribution to the
    betterment or continuation of the Society. The details of a "significant
    contribution" shall be determined by the current Primary Officers' Policy.
 
@@ -111,12 +113,14 @@ Alumni membership shall last indefinitely after acquisition unless directly
 contested. A candidate must satisfy all of the following requirements to have
 Alumni membership. 
 
-1. The candidate must not be enrolled as a student at RIT or NTID.
-2. The candidate must have earned Active membership while at RIT or NTID.
-3. The candidate must have applied for alumni membership within six months of
-   leaving RIT or NTID. Alumni membership can also be granted after the six
-   month time period upon approval of the Primary Officers. The Officers'
-   Policy shall specify the application process for Alumni membership.
+1. The candidate must not be enrolled as a student at the Rochester Institute
+   of Technology in Henrietta, New York, United States.
+3. The candidate must have earned Active membership while at the Rochester Institute
+   of Technology.
+5. The candidate must have applied for alumni membership within six months of
+   leaving the Rochester Institute of Technology. Alumni membership can also be
+   granted after the six month time period upon approval of the Primary Officers.
+   The Officers' Policy shall specify the application process for Alumni membership.
 
 
 ### Temporary Membership
@@ -132,7 +136,8 @@ Temporary membership may be granted for at most one academic term at the
 discretion of the Primary Officers if the following additional requirements are
 met:
 
-1. The candidate must be enrolled as a student at RIT or NTID. 
+1. The candidate must be enrolled as a student at the Rochester Institute of
+   Technology in Henrietta, New York, United States.
 2. The candidate must not ever have had a Temporary, Active, or Alumni
    membership in the Society.
 
@@ -290,10 +295,21 @@ Vice President  | 3             | 1 academic term
 Treasurer       | -             | 1 academic term
 Secretary       | -             | - 
 
-“Year level” is counted by the lower of [A] years enrolled at least part-time in a higher-education institution post high school graduation, or [B] by RIT credits obtained following the scale published by the RIT Office of the Registrar.  “Prior Involvement” refers to the number of complete academic terms during which the candidate served as a Primary Officer or Committee Head. In the event a candidate has not previously served as a Primary Officer or Committee Head, two complete academic terms during which the candidate served as a Mentor with the society may be substituted to serve as one term of “Prior Involvement”. No more than one term of “Prior Involvement” earned through mentorship may be substituted as the requirements for any office.
+“Year level” is counted by the lower of [A] years enrolled at least part-time in a
+higher-education institution post high school graduation, or [B] by credits obtained
+at the Rochester Institute of Technology following the scale published by the Rochester
+Institute of Technology's Office of the Registrar.
 
-All Primary Officers must be enrolled as full or part-time Software Engineering
-students attending classes at the RIT campus in Rochester, NY.
+“Prior Involvement” refers to the number of complete academic terms during which the
+candidate served as a Primary Officer or Committee Head. In the event a candidate has
+not previously served as a Primary Officer or Committee Head, two complete academic terms
+during which the candidate served as a Mentor with the society may be substituted to serve
+as one term of “Prior Involvement”. No more than one term of “Prior Involvement” earned
+through mentorship may be substituted as the requirements for any office.
+
+All Primary Officers must be enrolled as Software Engineering students at the
+Rochester Institute of Technology in Henrietta, New York, United States and
+not be on co-op.
 
 Candidates for President and Vice President must both plan to remain enrolled
 and on-campus for the entire academic year for which they are to serve.
@@ -347,9 +363,10 @@ temporary members cannot participate in this process.
 Committee Head Selection
 ------------------------
 ### Eligibility
-Any student at RIT may be nominated to be a Committee Head. Committee heads
-must be a full or part-time student at RIT and must not be on co-op during the
-term in which they will serve. Members cannot serve in Committee Head and
+Any student at the Rochester Institute of Technology may be nominated to be a
+Committee Head. All Committee Heads must be enrolled as Software Engineering
+students at the Rochester Institute of Technology in Henrietta, New York,
+United States and not be on co-op. Members cannot serve in Committee Head and
 Primary Officer positions concurrently.
 
 ### Nomination Process

--- a/app/markdown/governing-docs/constitution.md
+++ b/app/markdown/governing-docs/constitution.md
@@ -92,7 +92,7 @@ member:
 
 1. The candidate must be enrolled as a student at the Rochester Institute of
    Technology in Henrietta, New York, United States.
-3. The candidate must make at least one significant contribution to the
+2. The candidate must make at least one significant contribution to the
    betterment or continuation of the Society. The details of a "significant
    contribution" shall be determined by the current Primary Officers' Policy.
 
@@ -115,9 +115,9 @@ Alumni membership.
 
 1. The candidate must not be enrolled as a student at the Rochester Institute
    of Technology in Henrietta, New York, United States.
-3. The candidate must have earned Active membership while at the Rochester Institute
+2. The candidate must have earned Active membership while at the Rochester Institute
    of Technology.
-5. The candidate must have applied for alumni membership within six months of
+3. The candidate must have applied for alumni membership within six months of
    leaving the Rochester Institute of Technology. Alumni membership can also be
    granted after the six month time period upon approval of the Primary Officers.
    The Officers' Policy shall specify the application process for Alumni membership.


### PR DESCRIPTION
- Clear up no co-op requirement for Officers and make them consistent for Primaries & Committee Heads
- Remove explicit mention of NTID as it is part of RIT, not separate
- Specify Members must be enrolled at Henrietta, NY location